### PR TITLE
Fix case for path to HttpHandler

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -141,7 +141,7 @@
         </config-file>
         <header-file src="src/ios/Geofence-Plugin-Bridging-Header.h" />
         <source-file src="src/ios/GeofencePlugin.swift"/>
-        <source-file src="src/ios/HTTPHandler.swift"/>
+        <source-file src="src/ios/HttpHandler.swift"/>
         <source-file src="src/ios/SwiftData.swift"/>
         <source-file src="src/ios/SwiftyJson.swift"/>
         <source-file src="src/ios/KeychainItemAccessibility.swift"/>


### PR DESCRIPTION
The file name for `HttpHander` uses lower case for the `ttp`:

https://github.com/dvdgs88/cordova-plugin-geofence/blob/master/src/ios/HttpHandler.swift

This updates the plugin.xml to reflect this in the source file reference.